### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/AllAboard/AllAboard.version
+++ b/GameData/AllAboard/AllAboard.version
@@ -1,6 +1,6 @@
 {
     "NAME"     : "Docking Port Entry",
-    "URL"      : "https://github.com/severedsolo/DockingPortEntry/blob/master/GameData/AllAboard/AllAboard.version",
+    "URL"      : "https://github.com/severedsolo/AllAboard/raw/master/GameData/AllAboard/AllAboard.version",
     "DOWNLOAD" : "https://github.com/severedsolo/AllAboard/releases",
     "GITHUB" :
     {


### PR DESCRIPTION
The version file's URL property is not a valid link.
Now it's fixed.